### PR TITLE
Add Jest tests for product info extraction

### DIFF
--- a/extractProductInfo.js
+++ b/extractProductInfo.js
@@ -1,0 +1,15 @@
+function extractProductInfo(html) {
+  const nameMatch = html.match(/js-bottomTrackingAddComparison_targetText">(.*?)<\/span>/);
+  const numberMatch = html.match(/商品番号：([\w-]+)/);
+  const priceMatch = html.match(/a-price_value">¥([\d,]+)/);
+  const modelMatch = html.match(/型番\s[\d-]+\s(\d+)/);
+
+  return {
+    name: nameMatch ? nameMatch[1].trim() : null,
+    number: numberMatch ? numberMatch[1].trim() : null,
+    price: priceMatch ? priceMatch[1].replace(/,/g, '') : null,
+    model: modelMatch ? modelMatch[1].trim() : null,
+  };
+}
+
+module.exports = { extractProductInfo };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "macro-collection",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/extractProductInfo.test.js
+++ b/tests/extractProductInfo.test.js
@@ -1,0 +1,36 @@
+const { extractProductInfo } = require('../extractProductInfo');
+
+describe('extractProductInfo', () => {
+  test('extracts all fields', () => {
+    const html = `
+      <span class="a-span u-text-normal js-bottomTrackingAddComparison_targetText">Example Product</span>
+      <div>商品番号：ABC123</div>
+      <span class="a-price_value">¥1,234</span>
+      <div>型番 123-456 7890</div>`;
+    expect(extractProductInfo(html)).toEqual({
+      name: 'Example Product',
+      number: 'ABC123',
+      price: '1234',
+      model: '7890',
+    });
+  });
+
+  test('handles price with multiple commas', () => {
+    const html = `
+      <span class="a-span u-text-normal js-bottomTrackingAddComparison_targetText">Product</span>
+      <div>商品番号：XYZ789</div>
+      <span class="a-price_value">¥12,345,678</span>
+      <div>型番 000-1111 2222</div>`;
+    expect(extractProductInfo(html).price).toBe('12345678');
+  });
+
+  test('handles missing fields', () => {
+    const html = `<span class="a-span u-text-normal js-bottomTrackingAddComparison_targetText">Only Name</span>`;
+    expect(extractProductInfo(html)).toEqual({
+      name: 'Only Name',
+      number: null,
+      price: null,
+      model: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `extractProductInfo` utility
- configure Jest in `package.json`
- provide tests for name, number, price and model extraction including edge cases

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424c8df2148328b0126857964bf25c